### PR TITLE
[AXM-1219] Upgrades J2ObjC 

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -432,9 +432,9 @@
   </target>
 
   <property name="ivy_install_path" location="${user.home}/.ant/lib" />
-  <property name="ivy_bootstrap_url1" value="http://repo1.maven.org/maven2"/>
+  <property name="ivy_bootstrap_url1" value="https://repo1.maven.org/maven2"/>
   <!-- you might need to tweak this from china so it works -->
-  <property name="ivy_bootstrap_url2" value="http://uk.maven.org/maven2"/>
+  <property name="ivy_bootstrap_url2" value="https://uk.maven.org/maven2"/>
   <property name="ivy_checksum_sha1" value="c5ebf1c253ad4959a29f4acfe696ee48cdd9f473"/>
 
   <target name="ivy-availability-check" unless="ivy.available">

--- a/lucene/setup-j2objc.sh
+++ b/lucene/setup-j2objc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # TODO: Parameterize, error checking, temp file, etc.
-VERSION=1.0.2
+VERSION=2.5
 FILE=j2objc-$VERSION.zip
 URL=https://github.com/google/j2objc/releases/download/$VERSION/$FILE
 #URL=https://github.com/lukhnos/j2objc/releases/download/$VERSION/$FILE

--- a/lucene/translate.py
+++ b/lucene/translate.py
@@ -112,7 +112,6 @@ excluded = (
     # jre_emul. See the discussion here for porting considerations:
     # https://groups.google.com/forum/#!topic/j2objc-discuss/Rx7ioYfOaIU
     './analysis/common/src/java/org/apache/lucene/analysis/hunspell/ISO8859_14Decoder.java',  # nopep8
-    './analysis/common/src/java/org/apache/lucene/analysis/th/*.java',
     './analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java',  # nopep8
     './analysis/common/src/java/org/apache/lucene/analysis/util/SegmentingTokenizerBase.java',  # nopep8
 

--- a/lucene/translate.py
+++ b/lucene/translate.py
@@ -107,14 +107,6 @@ excluded = (
     # No need to translate j2objc annotations to Objective-C.
     './core/src/java/org/lukhnos/portmobile/j2objc/*',
 
-    # Currently skipped; these currently relies on JDK 7's BreakIterator,
-    # which, although supported on Android, is not implemented by j2objc's
-    # jre_emul. See the discussion here for porting considerations:
-    # https://groups.google.com/forum/#!topic/j2objc-discuss/Rx7ioYfOaIU
-    './analysis/common/src/java/org/apache/lucene/analysis/hunspell/ISO8859_14Decoder.java',  # nopep8
-    './analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java',  # nopep8
-    './analysis/common/src/java/org/apache/lucene/analysis/util/SegmentingTokenizerBase.java',  # nopep8
-
     # Requires antlr.
     './expressions/src/java/org/apache/lucene/expressions/js/*.java',
 


### PR DESCRIPTION
This upgrades J2ObjC to the latest version  and removes the logic to keeps the Thai analyzer from being added to the project. 

This was done to prevent the issue described here: https://groups.google.com/forum/#!topic/j2objc-discuss/Rx7ioYfOaIU